### PR TITLE
Put Mp3 Meta in the right folder

### DIFF
--- a/Source code/src/main/java/net/openaudiomc/jclient/utils/Mp3Reader.java
+++ b/Source code/src/main/java/net/openaudiomc/jclient/utils/Mp3Reader.java
@@ -47,7 +47,7 @@ public class Mp3Reader {
         InputStream is = null;
         FileOutputStream fos = null;
         String tempDir = System.getProperty("java.io.tmpdir");
-        String outputPath = "plugins/OpenAudioMp3Meta";
+        String outputPath = "plugins/OpenAudioMc/Mp3Meta";
         try {
             URLConnection urlConn = url.openConnection();
 


### PR DESCRIPTION
This would be of benefit since putting it straight in the plugins folder as it doesnt make sense to output there.

Path changed to /plugins/OpenAudioMc/Mp3Meta