### PR TITLE
Fix incorrect startInstant timestamp

### DIFF
--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/media/objects/Media.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/media/objects/Media.java
@@ -15,7 +15,7 @@ public class Media {
 
     //media information
     private String source;
-    private int startInstant;
+    @Setter @Getter private long startInstant;
     @Setter @Getter private transient int keepTimeout = -1;
     @Getter @Setter private Boolean doPickup = true;
     @Getter @Setter private Boolean loop = false;
@@ -31,7 +31,7 @@ public class Media {
      */
     public Media(String source) {
         this.source = OpenAudioMc.getInstance().getMediaModule().process(source);
-        this.startInstant = (int) (OpenAudioMc.getInstance().getTimeService().getSyncedInstant().toEpochMilli() / 1000);
+        this.startInstant = OpenAudioMc.getInstance().getTimeService().getSyncedInstant().toEpochMilli();
     }
 
     /**


### PR DESCRIPTION
The client expects a value in milliseconds, not seconds. Changed the data type because an int can't hold big enough values.
Fixes setDoPickup(true) not working with non-looped sounds.