### PR TITLE
Resolved destroy sounds issue

### DIFF
--- a/client/src/js/modules/media/MediaManager.js
+++ b/client/src/js/modules/media/MediaManager.js
@@ -22,7 +22,7 @@ export class MediaManager {
             console.log(channel)
             if (soundId == null || soundId === "") {
                 if ((!channel.hasTag("SPECIAL") && !channel.hasTag("REGION") && !channel.hasTag("SPEAKER")) || all) {
-                    channel.fadeChannel(250, () => {
+                    channel.fadeChannel(0, 250, () => {
                         this.mixer.removeChannel(channel);
                     });
                 }


### PR DESCRIPTION
Solved the following problem:
When switching from server the volume of a region played sound rises to 250 and don't get destroyed.