### PR TITLE
Update lastConnectPrompt when ticking a client

### DIFF
--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/client/objects/player/ClientConnection.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/client/objects/player/ClientConnection.java
@@ -214,6 +214,7 @@ public class ClientConnection implements Authenticatable, Client {
             int reminderInterval = OpenAudioMc.getInstance().getConfiguration().getInt(StorageKey.SETTINGS_REMIND_TO_CONNECT_INTERVAL);
             if (!getIsConnected() && (Duration.between(lastConnectPrompt, Instant.now()).toMillis() * 1000) > reminderInterval) {
                 player.sendMessage(Platform.translateColors(OpenAudioMc.getInstance().getConfiguration().getString(StorageKey.MESSAGE_PROMPT_TO_CONNECT)));
+                lastConnectPrompt = Instant.now();
             }
         }
     }


### PR DESCRIPTION
In the config there is an option to send the reminder every X number of seconds.
Because `lastConnectPrompt` is not updated, this cooldown will not work.

This problem is solved in this pull request.