### PR TITLE
Add {token} template to click-to-connect message.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ bin
 
 out
 out/*
+
+.vscode/*

--- a/plugin/src/main/java/com/craftmend/openaudiomc/bungee/modules/commands/commands/BungeeVolumeCommand.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/bungee/modules/commands/commands/BungeeVolumeCommand.java
@@ -42,9 +42,8 @@ public class BungeeVolumeCommand extends Command {
 
         if (!clientConnection.isConnected()) {
             sender.sendMessage(Platform.translateColors(
-                    StorageKey.MESSAGE_CLIENT_VOLUME_CHANGED.getString())
-                    .replaceAll("__amount__", clientConnection.getVolume() + ""
-                    ));
+                    StorageKey.MESSAGE_CLIENT_VOLUME_INVALID.getString())
+            );
             return;
         }
 

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/authentication/driver/AuthenticationDriver.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/authentication/driver/AuthenticationDriver.java
@@ -16,7 +16,6 @@ import lombok.AllArgsConstructor;
 
 import java.util.UUID;
 
-@AllArgsConstructor
 public class AuthenticationDriver {
 
     private AuthenticationService service;
@@ -24,10 +23,15 @@ public class AuthenticationDriver {
         return "";
     });
 
+    public AuthenticationDriver(AuthenticationService service) {
+        this.service = service;
+    }
+
     public Task<String> createPlayerSession(Authenticatable authenticatable) {
         Task<String> task = new Task<>();
         OpenAudioMc.getInstance().getTaskProvider().runAsync(() -> {
             // check ache, since there might be a value
+            sessionCacheMap.clean();
             HeatMap<UUID, String>.Value entry = sessionCacheMap.get(authenticatable.getOwnerUUID());
             if (!entry.getContext().isEmpty()) {
                 task.success(entry.getContext());

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/client/objects/player/Publisher.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/client/objects/player/Publisher.java
@@ -56,7 +56,7 @@ public class Publisher {
             String url = openAudioMc.getPlusService().getBaseUrl() + token;
 
             TextComponent message = new TextComponent(translateColors(Objects.requireNonNull(
-                    StorageKey.MESSAGE_CLICK_TO_CONNECT.getString().replace("{url}", url)
+                    StorageKey.MESSAGE_CLICK_TO_CONNECT.getString().replace("{url}", url).replace("{token}", token)
             )));
 
             TextComponent[] hover = new TextComponent[]{

--- a/plugin/src/main/java/com/craftmend/openaudiomc/spigot/modules/commands/command/VolumeCommand.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/spigot/modules/commands/command/VolumeCommand.java
@@ -42,9 +42,8 @@ public class VolumeCommand implements CommandExecutor {
 
             if (args.length == 0) {
                 sender.sendMessage(Platform.translateColors(
-                        StorageKey.MESSAGE_CLIENT_VOLUME_CHANGED.getString())
-                        .replaceAll("__amount__", spigotConnection.getClientConnection().getVolume() + ""
-                ));
+                        StorageKey.MESSAGE_CLIENT_VOLUME_INVALID.getString())
+                );
                 return true;
             }
 


### PR DESCRIPTION
For example, this can be used to rewrite the message as: "Visit audio.example.com and enter code **ABC123**". A modal dialog can be added to the audio client in the future to facilitate this when no token is provided.