### PR TITLE
Allow to specify volume & fadeTime to timed region

### DIFF
--- a/plugin/src/main/java/com/craftmend/openaudiomc/spigot/modules/regions/objects/TimedRegionProperties.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/spigot/modules/regions/objects/TimedRegionProperties.java
@@ -13,7 +13,11 @@ public class TimedRegionProperties extends RegionProperties {
     private Media media;
 
     public TimedRegionProperties(String source, int timeInSeconds, String id) {
-        super(source, 100, 1000);
+        this(source, timeInSeconds, id, 100, 1000);
+    }
+
+    public TimedRegionProperties(String source, int timeInSeconds, String id, int volume, int fadeTimeMs) {
+        super(source, volume, fadeTimeMs);
         this.id = id;
 
         this.task = Bukkit.getScheduler().scheduleAsyncDelayedTask(OpenAudioMcSpigot.getInstance(), () -> {
@@ -21,7 +25,7 @@ public class TimedRegionProperties extends RegionProperties {
             forceUpdateClients();
         }, 20 * timeInSeconds);
 
-        this.media = new RegionMedia(source, 100, 1000);
+        this.media = new RegionMedia(source, volume, fadeTimeMs);
         this.media.setLoop(OpenAudioMc.getInstance().getConfiguration().getBoolean(StorageKey.SETTINGS_LOOP_TEMP_REGIONS));
         forceUpdateClients();
     }


### PR DESCRIPTION
# Why 
When creating a TimedRegion, one might need different values for volume and fadeTime. And there is no command argument for that. 

# How
Add a constructor to explicitly specify the volume and fadeTimeMs. Preserve the existing constructor and keep the default values.