### PR TITLE
WIP: Redis sending issues

### DIFF
--- a/plugin/src/main/java/com/craftmend/openaudiomc/OpenAudioMc.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/OpenAudioMc.java
@@ -5,6 +5,8 @@ import com.craftmend.openaudiomc.generic.authentication.AuthenticationService;
 import com.craftmend.openaudiomc.generic.commands.CommandModule;
 import com.craftmend.openaudiomc.generic.networking.rest.ServerEnvironment;
 import com.craftmend.openaudiomc.generic.platform.interfaces.OpenAudioInvoker;
+import com.craftmend.openaudiomc.generic.redis.packets.ExecuteBulkCommandsPacket;
+import com.craftmend.openaudiomc.generic.redis.packets.ExecuteCommandPacket;
 import com.craftmend.openaudiomc.generic.storage.interfaces.ConfigurationImplementation;
 import com.craftmend.openaudiomc.generic.logging.OpenAudioLogger;
 import com.craftmend.openaudiomc.generic.media.MediaModule;
@@ -89,6 +91,7 @@ public class OpenAudioMc {
             .registerTypeAdapter(AbstractPacketPayload.class, new AbstractPacketAdapter())
             .registerTypeAdapter(ShowRunnable.class, new RunnableTypeAdapter())
             .registerTypeAdapter(OARedisPacket.class, new RedisTypeAdapter())
+            .registerTypeAdapter(ExecuteBulkCommandsPacket.class, new RedisTypeAdapter())
             .create();
 
     public OpenAudioMc(OpenAudioInvoker invoker) throws Exception {

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/redis/RedisService.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/redis/RedisService.java
@@ -59,7 +59,9 @@ public class RedisService {
 
         // if there are bulk packets waiting, send them
         if (commands.isEmpty()) return;
-        asyncPub.publish(ChannelKey.TRIGGER_BULK_COMMANDS.getRedisChannelName(), new ExecuteBulkCommandsPacket(commands).serialize());
+        ExecuteBulkCommandsPacket packet = new ExecuteBulkCommandsPacket(commands);
+        packet.setSenderUUID(getServiceId());
+        asyncPub.publish(ChannelKey.TRIGGER_BULK_COMMANDS.getRedisChannelName(), packet.serialize());
     };
 
     public RedisService(ConfigurationImplementation ConfigurationImplementation) {

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/redis/packets/adapter/RedisTypeAdapter.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/redis/packets/adapter/RedisTypeAdapter.java
@@ -17,7 +17,7 @@ public class RedisTypeAdapter implements JsonSerializer<OARedisPacket>, JsonDese
         JsonObject result = new JsonObject();
 
         result.add("type", new JsonPrimitive(src.getClass().getName()));
-        result.add("payload", context.serialize(src, src.getClass()));
+//        result.add("payload", context.serialize(src, src.getClass()));
         result.add("senderUuid", new JsonPrimitive(src.getSenderUUID().toString()));
 
         return result;

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/redis/packets/adapter/RedisTypeAdapter.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/redis/packets/adapter/RedisTypeAdapter.java
@@ -28,6 +28,7 @@ public class RedisTypeAdapter implements JsonSerializer<OARedisPacket>, JsonDese
         JsonObject jsonObject = json.getAsJsonObject();
         String type = jsonObject.get("type").getAsString();
         String senderUuid = jsonObject.get("senderUuid").getAsString();
+        //
         JsonElement element = jsonObject.get("payload");
 
         try {

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/redis/packets/interfaces/OARedisPacket.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/redis/packets/interfaces/OARedisPacket.java
@@ -12,6 +12,7 @@ public abstract class OARedisPacket {
     public abstract String serialize();
 
     public OARedisPacket deSerialize(String json) {
+
         return OpenAudioMc.getGson().fromJson(json, getClass());
     }
 


### PR DESCRIPTION
Those are not necessarily fixes, just an analysis for now.

## Symptoms
When the master server transmits a bulk command, it's supposed to add its own service id (senderUUID), to be able to recognize when a redis message comes from itself. But when listening to the messages, the senderUUID is not in the message.

## Steps to reproduce
- listen externally to the `oa-show-bulk` redis channel
- `/oa show start test` 
- observe the sent messages: the senderUUID is not present
- the show starts twice (once via the command, once via redis, because it's not recognized as coming from itself)

