### PR TITLE
item-nbt-api dependancy update due to 2.9.0 causing problems

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -109,7 +109,7 @@
         <dependency>
             <groupId>de.tr7zw</groupId>
             <artifactId>item-nbt-api</artifactId>
-            <version>2.9.0-SNAPSHOT</version>
+            <version>2.10.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
switched to item-nbt-api 2.10.0, as 2.9.0 wasn't working on 1.19 spigot server