### PR TITLE
Added support for Redis Sentinel

### DIFF
--- a/dev-resources/redis-sentinel/docker-compose.yml
+++ b/dev-resources/redis-sentinel/docker-compose.yml
@@ -1,0 +1,67 @@
+version: '3.9'
+
+services:
+  master:
+    image: "bitnami/redis:7.2.1"
+    environment:
+      - REDIS_DISABLE_COMMANDS=FLUSHDB,FLUSHALL,CONFIG
+      - REDIS_AOF_ENABLED=no
+      - ALLOW_EMPTY_PASSWORD=no
+      - REDIS_PASSWORD=passwd
+      - REDIS_REPLICATION_MODE=master
+    network_mode: host
+
+  replica:
+    image: "bitnami/redis:7.2.1"
+    environment:
+      - REDIS_REPLICATION_MODE=slave
+      - REDIS_MASTER_HOST=127.0.0.1
+      - REDIS_MASTER_PASSWORD=passwd
+      - REDIS_PASSWORD=passwd
+      - REDIS_MASTER_PORT_NUMBER=6379
+      - REDIS_PORT_NUMBER=6380
+    depends_on:
+      - master
+    network_mode: host
+
+  sentinel-1:
+    image: 'bitnami/redis-sentinel:7.2.1'
+    environment:
+      - REDIS_MASTER_HOST=127.0.0.1
+      - REDIS_MASTER_SET=master
+      - REDIS_MASTER_PASSWORD=passwd
+      - REDIS_SENTINEL_PASSWORD=passwd
+      - REDIS_SENTINEL_DOWN_AFTER_MILLISECONDS=30000
+      - REDIS_SENTINEL_PORT_NUMBER=26379
+    depends_on:
+      - master
+      - replica
+    network_mode: host
+
+  sentinel-2:
+    image: 'bitnami/redis-sentinel:7.2.1'
+    environment:
+      - REDIS_MASTER_HOST=127.0.0.1
+      - REDIS_MASTER_SET=master
+      - REDIS_MASTER_PASSWORD=passwd
+      - REDIS_SENTINEL_PASSWORD=passwd
+      - REDIS_SENTINEL_DOWN_AFTER_MILLISECONDS=30000
+      - REDIS_SENTINEL_PORT_NUMBER=26380
+    depends_on:
+      - master
+      - replica
+    network_mode: host
+
+  sentinel-3:
+    image: 'bitnami/redis-sentinel:7.2.1'
+    environment:
+      - REDIS_MASTER_HOST=127.0.0.1
+      - REDIS_MASTER_SET=master
+      - REDIS_MASTER_PASSWORD=passwd
+      - REDIS_SENTINEL_PASSWORD=passwd
+      - REDIS_SENTINEL_DOWN_AFTER_MILLISECONDS=30000
+      - REDIS_SENTINEL_PORT_NUMBER=26381
+    depends_on:
+      - master
+      - replica
+    network_mode: host

--- a/modules/vistas-client/src/main/java/com/craftmend/openaudiomc/vistas/client/client/VistasRedisClient.java
+++ b/modules/vistas-client/src/main/java/com/craftmend/openaudiomc/vistas/client/client/VistasRedisClient.java
@@ -35,6 +35,8 @@ public class VistasRedisClient extends Service {
                 configuration.getString(StorageKey.REDIS_HOST),
                 configuration.getInt(StorageKey.REDIS_PORT),
                 configuration.getString(StorageKey.REDIS_PASSWORD),
+                configuration.getBoolean(StorageKey.REDIS_USE_SSL),
+                configuration.getString(StorageKey.REDIS_SENTINEL_MASTER_SET),
                 packetEvents,
                 "deputy_to_server"
         );

--- a/modules/vistas-client/src/main/java/com/craftmend/openaudiomc/vistas/client/client/VistasRedisClient.java
+++ b/modules/vistas-client/src/main/java/com/craftmend/openaudiomc/vistas/client/client/VistasRedisClient.java
@@ -30,7 +30,6 @@ public class VistasRedisClient extends Service {
         // setup handler
         packetEvents = new DefaultPacketHandler();
         packetEvents.setSelfId(Vistas.getInstance().getServerId());
-        OpenAudioLogger.toConsole("Connecting to redis server: " + configuration.getString(StorageKey.REDIS_HOST));
         redis = new SimpleRedisClient(
                 configuration.getString(StorageKey.REDIS_HOST),
                 configuration.getInt(StorageKey.REDIS_PORT),

--- a/modules/vistas-client/src/main/java/com/craftmend/openaudiomc/vistas/client/redis/RedisConnection.java
+++ b/modules/vistas-client/src/main/java/com/craftmend/openaudiomc/vistas/client/redis/RedisConnection.java
@@ -1,6 +1,8 @@
 package com.craftmend.openaudiomc.vistas.client.redis;
 
-import com.craftmend.openaudiomc.generic.utils.redis.RedisUtils;
+import com.craftmend.openaudiomc.generic.logging.OpenAudioLogger;
+import com.craftmend.openaudiomc.generic.storage.enums.StorageKey;
+import com.craftmend.openaudiomc.vistas.client.utils.RedisUtils;
 import io.lettuce.core.ClientOptions;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
@@ -42,6 +44,8 @@ public class RedisConnection {
             }
             uri = builder.build();
         }
+
+        OpenAudioLogger.toConsole("Connecting to redis server: " + uri.toString());
 
         redisClient = RedisClient.create(uri);
         redisClient.setOptions(ClientOptions.builder().autoReconnect(true).build());

--- a/modules/vistas-client/src/main/java/com/craftmend/openaudiomc/vistas/client/redis/RedisConnection.java
+++ b/modules/vistas-client/src/main/java/com/craftmend/openaudiomc/vistas/client/redis/RedisConnection.java
@@ -1,5 +1,6 @@
 package com.craftmend.openaudiomc.vistas.client.redis;
 
+import com.craftmend.openaudiomc.generic.utils.redis.RedisUtils;
 import io.lettuce.core.ClientOptions;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
@@ -37,11 +38,7 @@ public class RedisConnection {
                     .withSsl(useSSL)
                     .withSentinelMasterId(sentinelMasterSet);
             for (final String h : host.split(",")) {
-                builder.withSentinel(RedisURI.builder()
-                        .withHost(h.contains(":") ? h.split(":")[0] : h)
-                        .withPort(h.contains(":") ? Integer.parseInt(h.split(":")[1]) : 26379)
-                        .withPassword(pass)
-                        .build());
+                builder.withSentinel(RedisUtils.readRedisUri(h, 26379));
             }
             uri = builder.build();
         }

--- a/modules/vistas-client/src/main/java/com/craftmend/openaudiomc/vistas/client/redis/SimpleRedisClient.java
+++ b/modules/vistas-client/src/main/java/com/craftmend/openaudiomc/vistas/client/redis/SimpleRedisClient.java
@@ -9,11 +9,18 @@ public class SimpleRedisClient extends RedisPubSubAdapter<String, String> {
     private RedisConnection senderConnection;
     private RedisConnection listenerConnection;
 
-    public SimpleRedisClient(String host, int port, String password, IRedisHandler handler, String... channels) {
+    public SimpleRedisClient(String host,
+                             int port,
+                             String password,
+                             boolean useSSL,
+                             String sentinelMasterSet,
+                             IRedisHandler handler,
+                             String... channels
+    ) {
         this.handler = handler;
-        this.senderConnection = new RedisConnection(host, port, password)
+        this.senderConnection = new RedisConnection(host, port, password, useSSL, sentinelMasterSet)
             .connectPubSub();
-        this.listenerConnection = new RedisConnection(host, port, password)
+        this.listenerConnection = new RedisConnection(host, port, password, useSSL, sentinelMasterSet)
             .connectPubSub();
 
         // listen to packets from Spigot To Deputy

--- a/modules/vistas-client/src/main/java/com/craftmend/openaudiomc/vistas/client/server/networking/VistasRedisServer.java
+++ b/modules/vistas-client/src/main/java/com/craftmend/openaudiomc/vistas/client/server/networking/VistasRedisServer.java
@@ -35,7 +35,6 @@ public class VistasRedisServer extends Service {
     public VistasRedisServer(Configuration configuration) {
         // setup handler
         packetEvents = new DefaultPacketHandler();
-        OpenAudioLogger.toConsole("Connecting to redis server: " + configuration.getString(StorageKey.REDIS_HOST));
         redis = new SimpleRedisClient(
                 configuration.getString(StorageKey.REDIS_HOST),
                 configuration.getInt(StorageKey.REDIS_PORT),

--- a/modules/vistas-client/src/main/java/com/craftmend/openaudiomc/vistas/client/server/networking/VistasRedisServer.java
+++ b/modules/vistas-client/src/main/java/com/craftmend/openaudiomc/vistas/client/server/networking/VistasRedisServer.java
@@ -40,6 +40,8 @@ public class VistasRedisServer extends Service {
                 configuration.getString(StorageKey.REDIS_HOST),
                 configuration.getInt(StorageKey.REDIS_PORT),
                 configuration.getString(StorageKey.REDIS_PASSWORD),
+                configuration.getBoolean(StorageKey.REDIS_USE_SSL),
+                configuration.getString(StorageKey.REDIS_SENTINEL_MASTER_SET),
                 packetEvents,
                 "server_to_deputy"
         );

--- a/modules/vistas-client/src/main/java/com/craftmend/openaudiomc/vistas/client/utils/RedisUtils.java
+++ b/modules/vistas-client/src/main/java/com/craftmend/openaudiomc/vistas/client/utils/RedisUtils.java
@@ -1,0 +1,25 @@
+package com.craftmend.openaudiomc.vistas.client.utils;
+
+import io.lettuce.core.RedisURI;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class RedisUtils {
+
+    private static final Pattern URI_FORMAT = Pattern.compile("^(?:(.+)@)?([a-zA-Z0-9.]+)(?::([0-9]{1,5}))?$");
+
+    private RedisUtils() {
+    }
+
+    public static RedisURI readRedisUri(String str, int defaultPort) {
+        final Matcher matcher = URI_FORMAT.matcher(str);
+        if (!matcher.matches())
+            return null;
+        return RedisURI.builder()
+                .withHost(matcher.group(2))
+                .withPort(matcher.group(3) == null ? defaultPort : Integer.parseInt(matcher.group(3)))
+                .withPassword(matcher.group(1) == null ? null : matcher.group(1).toCharArray())
+                .build();
+    }
+}

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/migrations/MigrationWorker.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/migrations/MigrationWorker.java
@@ -59,6 +59,7 @@ public class MigrationWorker {
                 new TokenMessageMigration(),            // adds the token message
                 new AddVehicleRegionConfigMigration(),  // adds the option to disable regions while in a vehicle
                 new VoicechatDeafenMigration(),         // adds the option to deafen yourself
+                new AddRedisSentinelMigration(),         // adds the option to use redis sentinel
         };
 
         for (SimpleMigration migration : migrations) {

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/migrations/migrations/AddRedisSentinelMigration.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/migrations/migrations/AddRedisSentinelMigration.java
@@ -1,0 +1,22 @@
+package com.craftmend.openaudiomc.generic.migrations.migrations;
+
+import com.craftmend.openaudiomc.OpenAudioMc;
+import com.craftmend.openaudiomc.generic.migrations.MigrationWorker;
+import com.craftmend.openaudiomc.generic.migrations.interfaces.SimpleMigration;
+import com.craftmend.openaudiomc.generic.storage.enums.StorageKey;
+import com.craftmend.openaudiomc.generic.storage.interfaces.Configuration;
+
+public class AddRedisSentinelMigration extends SimpleMigration {
+
+    @Override
+    public boolean shouldBeRun(MigrationWorker migrationWorker) {
+        Configuration config = OpenAudioMc.getInstance().getConfiguration();
+        return !config.hasStorageKey(StorageKey.REDIS_SENTINEL_MASTER_SET);
+    }
+
+    @Override
+    public void execute(MigrationWorker migrationWorker) {
+        migrateFilesFromResources();
+    }
+}
+

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/redis/RedisService.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/redis/RedisService.java
@@ -3,17 +3,17 @@ package com.craftmend.openaudiomc.generic.redis;
 import com.craftmend.openaudiomc.OpenAudioMc;
 import com.craftmend.openaudiomc.generic.commands.CommandService;
 import com.craftmend.openaudiomc.generic.commands.subcommands.RedisSubCommand;
-import com.craftmend.openaudiomc.generic.platform.interfaces.TaskService;
-import com.craftmend.openaudiomc.generic.service.Inject;
-import com.craftmend.openaudiomc.generic.service.Service;
-import com.craftmend.openaudiomc.generic.storage.interfaces.Configuration;
 import com.craftmend.openaudiomc.generic.logging.OpenAudioLogger;
+import com.craftmend.openaudiomc.generic.platform.interfaces.TaskService;
 import com.craftmend.openaudiomc.generic.redis.packets.ExecuteBulkCommandsPacket;
 import com.craftmend.openaudiomc.generic.redis.packets.ExecuteCommandPacket;
 import com.craftmend.openaudiomc.generic.redis.packets.channels.ChannelKey;
 import com.craftmend.openaudiomc.generic.redis.packets.interfaces.OARedisPacket;
 import com.craftmend.openaudiomc.generic.redis.packets.models.WaitingPacket;
+import com.craftmend.openaudiomc.generic.service.Inject;
+import com.craftmend.openaudiomc.generic.service.Service;
 import com.craftmend.openaudiomc.generic.storage.enums.StorageKey;
+import com.craftmend.openaudiomc.generic.storage.interfaces.Configuration;
 import io.lettuce.core.ClientOptions;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
@@ -32,7 +32,6 @@ public class RedisService extends Service {
     // dependencies
     @Inject
     private Configuration Configuration;
-
     private RedisClient redisPub;
     private RedisClient redisSub;
     private RedisURI uri;
@@ -82,19 +81,30 @@ public class RedisService extends Service {
 
         OpenAudioLogger.toConsole("Enabling redis service..");
 
-        if (Configuration.getString(StorageKey.REDIS_PASSWORD).equals("none")) {
+        // Read Redis password
+        final String redisPass = Configuration.getString(StorageKey.REDIS_PASSWORD);
+        final char[] password = redisPass.isEmpty() || redisPass.equals("none") ? null : redisPass.toCharArray();
+
+        if (Configuration.getString(StorageKey.REDIS_SENTINEL_MASTER_SET).isEmpty()) {
             uri = RedisURI.builder()
+                    .withPassword(password)
                     .withHost(Configuration.getString(StorageKey.REDIS_HOST))
                     .withPort(Configuration.getInt(StorageKey.REDIS_PORT))
                     .withSsl(Configuration.getBoolean(StorageKey.REDIS_USE_SSL))
                     .build();
         } else {
-            uri = RedisURI.builder()
-                    .withPassword(Configuration.getString(StorageKey.REDIS_PASSWORD))
-                    .withHost(Configuration.getString(StorageKey.REDIS_HOST))
-                    .withPort(Configuration.getInt(StorageKey.REDIS_PORT))
+            final RedisURI.Builder builder = RedisURI.builder()
+                    .withPassword(password)
                     .withSsl(Configuration.getBoolean(StorageKey.REDIS_USE_SSL))
-                    .build();
+                    .withSentinelMasterId(Configuration.getString(StorageKey.REDIS_SENTINEL_MASTER_SET));
+            for (final String host : Configuration.getString(StorageKey.REDIS_HOST).split(",")) {
+                builder.withSentinel(RedisURI.builder()
+                        .withHost(host.contains(":") ? host.split(":")[0] : host)
+                        .withPort(host.contains(":") ? Integer.parseInt(host.split(":")[1]) : 26379)
+                        .withPassword(password)
+                        .build());
+            }
+            uri = builder.build();
         }
 
         // set up listener

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/redis/RedisService.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/redis/RedisService.java
@@ -14,6 +14,7 @@ import com.craftmend.openaudiomc.generic.service.Inject;
 import com.craftmend.openaudiomc.generic.service.Service;
 import com.craftmend.openaudiomc.generic.storage.enums.StorageKey;
 import com.craftmend.openaudiomc.generic.storage.interfaces.Configuration;
+import com.craftmend.openaudiomc.generic.utils.redis.RedisUtils;
 import io.lettuce.core.ClientOptions;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
@@ -98,11 +99,7 @@ public class RedisService extends Service {
                     .withSsl(Configuration.getBoolean(StorageKey.REDIS_USE_SSL))
                     .withSentinelMasterId(Configuration.getString(StorageKey.REDIS_SENTINEL_MASTER_SET));
             for (final String host : Configuration.getString(StorageKey.REDIS_HOST).split(",")) {
-                builder.withSentinel(RedisURI.builder()
-                        .withHost(host.contains(":") ? host.split(":")[0] : host)
-                        .withPort(host.contains(":") ? Integer.parseInt(host.split(":")[1]) : 26379)
-                        .withPassword(password)
-                        .build());
+                builder.withSentinel(RedisUtils.readRedisUri(host, 26379));
             }
             uri = builder.build();
         }

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/redis/RedisService.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/redis/RedisService.java
@@ -104,6 +104,8 @@ public class RedisService extends Service {
             uri = builder.build();
         }
 
+        OpenAudioLogger.toConsole("Connecting to redis server: " + uri.toString());
+
         // set up listener
         redisSub = RedisClient.create(uri);
         redisSub.setOptions(ClientOptions.builder().autoReconnect(true).build());

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/storage/enums/StorageKey.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/storage/enums/StorageKey.java
@@ -96,6 +96,7 @@ public enum StorageKey {
     REDIS_PASSWORD(false, "redis.password", StorageLocation.CONFIG_FILE),
     REDIS_USE_SSL(false, "redis.useSSL", StorageLocation.CONFIG_FILE),
     REDIS_SECTION(false, "redis.section", StorageLocation.CONFIG_FILE),
+    REDIS_SENTINEL_MASTER_SET(false, "redis.sentinel-master-set", StorageLocation.CONFIG_FILE),
 
     CDN_PREFERRED_PORT(false, "cdn.preferred-bridge-port", StorageLocation.CONFIG_FILE),
     CDN_TIMEOUT(false, "cdn.timeout-seconds", StorageLocation.CONFIG_FILE),

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/utils/redis/RedisUtils.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/utils/redis/RedisUtils.java
@@ -1,0 +1,25 @@
+package com.craftmend.openaudiomc.generic.utils.redis;
+
+import io.lettuce.core.RedisURI;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class RedisUtils {
+
+    private static final Pattern URI_FORMAT = Pattern.compile("^((.+)@)?([a-zA-Z0-9.]+)(:([0-9]{1,5}))?$");
+
+    private RedisUtils() {
+    }
+
+    public static RedisURI readRedisUri(String str, int defaultPort) {
+        final Matcher matcher = URI_FORMAT.matcher(str);
+        if (!matcher.matches())
+            return null;
+        return RedisURI.builder()
+                .withHost(matcher.group(3))
+                .withPort(matcher.group(5) == null ? defaultPort : Integer.parseInt(matcher.group(5)))
+                .withPassword(matcher.group(2) == null ? null : matcher.group(2).toCharArray())
+                .build();
+    }
+}

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/utils/redis/RedisUtils.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/utils/redis/RedisUtils.java
@@ -7,7 +7,7 @@ import java.util.regex.Pattern;
 
 public final class RedisUtils {
 
-    private static final Pattern URI_FORMAT = Pattern.compile("^((.+)@)?([a-zA-Z0-9.]+)(:([0-9]{1,5}))?$");
+    private static final Pattern URI_FORMAT = Pattern.compile("^(?:(.+)@)?([a-zA-Z0-9.]+)(?::([0-9]{1,5}))?$");
 
     private RedisUtils() {
     }
@@ -17,9 +17,9 @@ public final class RedisUtils {
         if (!matcher.matches())
             return null;
         return RedisURI.builder()
-                .withHost(matcher.group(3))
-                .withPort(matcher.group(5) == null ? defaultPort : Integer.parseInt(matcher.group(5)))
-                .withPassword(matcher.group(2) == null ? null : matcher.group(2).toCharArray())
+                .withHost(matcher.group(2))
+                .withPort(matcher.group(3) == null ? defaultPort : Integer.parseInt(matcher.group(3)))
+                .withPassword(matcher.group(1) == null ? null : matcher.group(1).toCharArray())
                 .build();
     }
 }

--- a/plugin/src/main/resources/config.yml
+++ b/plugin/src/main/resources/config.yml
@@ -244,3 +244,5 @@ redis:
   useSSL: false
   # The channel to sync with. When configured, OpenAudioMc will only sync to servers on redis with the same section
   section: event
+  # When using Redis Sentinel, you should set the master set to use. Leaves empty to use a single server Redis cluster
+  sentinel-master-set: ''


### PR DESCRIPTION
## Current limitations:

- ~~The node password and the sentinel password should be the same (if any) ;~~
- ~~IPv6 is not supported because the `split(":")` assume only one `:` (between the IP and the port), which isn't true for IPv6.~~

Limitations gone since https://github.com/Mindgamesnl/OpenAudioMc/pull/375/commits/39bf0956f845dd7232cfc183eb15a7682fe9c773

## Testing setup

`config.yml`
```yml
redis:
  # When set to true, the redis service will be enabled
  enabled: true
  # The host of your redis server
  host: '127.0.0.1:26379,127.0.0.1:26380,127.0.0.1:26381'
  # The port of your redis server
  port: 6379
  # The password to your redis server.
  # Leave set to "none" to connect without authentication
  password: 'passwd'
  # If SSL should be used to connect to your redis server (only if you have setup TLS)
  useSSL: false
  # The channel to sync with. When configured, OpenAudioMc will only sync to servers on redis with the same section
  section: event
  # When using Redis Sentinel, you should set the master set to use. Leaves empty to use a single server Redis cluster
  sentinel-master-set: 'master'
```

`docker-compose.yml`
```yml
version: '3.9'

services:
  master:
    image: "bitnami/redis:7.2.1"
    environment:
      - REDIS_DISABLE_COMMANDS=FLUSHDB,FLUSHALL,CONFIG
      - REDIS_AOF_ENABLED=no
      - ALLOW_EMPTY_PASSWORD=no
      - REDIS_PASSWORD=passwd
      - REDIS_REPLICATION_MODE=master
    network_mode: host
  replica:
    image: "bitnami/redis:7.2.1"
    environment:
      - REDIS_REPLICATION_MODE=slave
      - REDIS_MASTER_HOST=127.0.0.1
      - REDIS_MASTER_PASSWORD=passwd
      - REDIS_PASSWORD=passwd
      - REDIS_MASTER_PORT_NUMBER=6379
      - REDIS_PORT_NUMBER=6380
    depends_on:
      - master
    network_mode: host
  sentinel-1:
    image: 'bitnami/redis-sentinel:7.2.1'
    environment:
      - REDIS_MASTER_HOST=127.0.0.1
      - REDIS_MASTER_SET=master
      - REDIS_MASTER_PASSWORD=passwd
      - REDIS_SENTINEL_PASSWORD=passwd
      - REDIS_SENTINEL_DOWN_AFTER_MILLISECONDS=30000
      - REDIS_SENTINEL_PORT_NUMBER=26379
    depends_on:
      - master
      - replica
    network_mode: host
  sentinel-2:
    image: 'bitnami/redis-sentinel:7.2.1'
    environment:
      - REDIS_MASTER_HOST=127.0.0.1
      - REDIS_MASTER_SET=master
      - REDIS_MASTER_PASSWORD=passwd
      - REDIS_SENTINEL_PASSWORD=passwd
      - REDIS_SENTINEL_DOWN_AFTER_MILLISECONDS=30000
      - REDIS_SENTINEL_PORT_NUMBER=26380
    depends_on:
      - master
      - replica
    network_mode: host
  sentinel-3:
    image: 'bitnami/redis-sentinel:7.2.1'
    environment:
      - REDIS_MASTER_HOST=127.0.0.1
      - REDIS_MASTER_SET=master
      - REDIS_MASTER_PASSWORD=passwd
      - REDIS_SENTINEL_PASSWORD=passwd
      - REDIS_SENTINEL_DOWN_AFTER_MILLISECONDS=30000
      - REDIS_SENTINEL_PORT_NUMBER=26381
    depends_on:
      - master
      - replica
    network_mode: host
```