### PR TITLE
[fix] wait until teleportation went through before re-updating player…

### DIFF
--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/modules/ModuleLoaderService.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/modules/ModuleLoaderService.java
@@ -20,7 +20,6 @@ import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
-import java.util.Map;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 

--- a/plugin/src/main/java/com/craftmend/openaudiomc/spigot/modules/players/listeners/PlayerTeleportationListener.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/spigot/modules/players/listeners/PlayerTeleportationListener.java
@@ -1,26 +1,35 @@
 package com.craftmend.openaudiomc.spigot.modules.players.listeners;
 
 import com.craftmend.openaudiomc.OpenAudioMc;
+import com.craftmend.openaudiomc.spigot.OpenAudioMcSpigot;
 import com.craftmend.openaudiomc.spigot.modules.players.SpigotPlayerService;
 import com.craftmend.openaudiomc.spigot.modules.players.objects.SpigotConnection;
+import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerTeleportEvent;
 
 public class PlayerTeleportationListener implements Listener {
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onTp(PlayerTeleportEvent event) {
-        // this event might be called before the player is registered, as some plugins use
-        // the teleport event to warp them to spawn, instead of the player spawn event
-        if (!OpenAudioMc.getService(SpigotPlayerService.class).hasClient(event.getPlayer())) return;
 
-        SpigotConnection spigotConnection = OpenAudioMc.getService(SpigotPlayerService.class).getClient(event.getPlayer());
-        if (spigotConnection == null) return;
-        if (spigotConnection.getRegionHandler() != null) {
-            spigotConnection.getRegionHandler().tick();
-        }
-        spigotConnection.getSpeakerHandler().tick();
+        // run a tick later, to run post teleport if the player actually moved
+        Bukkit.getScheduler().runTaskLater(OpenAudioMcSpigot.getInstance(), () -> {
+            if (event.isCancelled()) return;
+
+            // this event might be called before the player is registered, as some plugins use
+            // the teleport event to warp them to spawn, instead of the player spawn event
+            if (!OpenAudioMc.getService(SpigotPlayerService.class).hasClient(event.getPlayer())) return;
+
+            SpigotConnection spigotConnection = OpenAudioMc.getService(SpigotPlayerService.class).getClient(event.getPlayer());
+            if (spigotConnection == null) return;
+            if (spigotConnection.getRegionHandler() != null) {
+                spigotConnection.getRegionHandler().tick();
+            }
+            spigotConnection.getSpeakerHandler().tick();
+        }, 1);
     }
 
 }


### PR DESCRIPTION
Possible fix for regions not updating properly on teleport, if my assumption is correct that it is caused by modern async teleport handling. Will need to be tested when I have some time tomorrow or this weekend. This PR will be a draft for now.