### PR TITLE
New event driver + api

### DIFF
--- a/plugin/src/main/java/com/craftmend/openaudiomc/OpenAudioMc.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/OpenAudioMc.java
@@ -11,6 +11,7 @@ import com.craftmend.openaudiomc.generic.database.DatabaseService;
 import com.craftmend.openaudiomc.generic.environment.EnvironmentService;
 import com.craftmend.openaudiomc.generic.environment.GlobalConstantService;
 import com.craftmend.openaudiomc.generic.environment.MagicValue;
+import com.craftmend.openaudiomc.generic.events.EventService;
 import com.craftmend.openaudiomc.generic.logging.OpenAudioLogger;
 import com.craftmend.openaudiomc.generic.media.MediaService;
 import com.craftmend.openaudiomc.generic.media.time.TimeService;
@@ -137,6 +138,7 @@ public class OpenAudioMc {
 
         // load core services in order
         serviceManager.loadServices(
+                EventService.class,             // platform agnostic event manager
                 DatabaseService.class,          // player and profile storage
                 EnvironmentService.class,       // env loader
                 MojangLookupService.class,      // handles caching of uuid's > names

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/events/EventService.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/events/EventService.java
@@ -1,0 +1,6 @@
+package com.craftmend.openaudiomc.generic.events;
+
+import com.craftmend.openaudiomc.generic.service.Service;
+
+public class EventService extends Service {
+}


### PR DESCRIPTION
Setup new event api which is actually usable for the separate API maven package.
Goals:
- platform agnostic
- only depend on whats available within the api package
- "internal" events which must include internal classes, such as state changes, should be in the plugin package itself and not exposed to the API
- current events should be marked as deprecated, and translated where possible (not fully baked because this will be deleted eventually)