### PR TITLE
Cancellable peer connections

### DIFF
--- a/api/src/main/java/com/craftmend/openaudiomc/api/clients/Client.java
+++ b/api/src/main/java/com/craftmend/openaudiomc/api/clients/Client.java
@@ -67,4 +67,13 @@ public interface Client {
      */
     void playMedia(@NotNull Media media);
 
+    /**
+     * Forcefully remove a player from my proximity chat peers. This will cause the otherClient to trigger a new ClientPeerAddEvent
+     * Useful for refreshing peers when someone changes game modes, for example.
+     * This method will not do anything if this user isn't in voice chat, if they aren't a peer, or if the other client isn't in voice chat.
+     * This action is **one-sided**. The other client will still be listening to this client.
+     * @param otherClient the client to remove
+     */
+    void kickProximityPeer(@NotNull Client otherClient);
+
 }

--- a/api/src/main/java/com/craftmend/openaudiomc/api/events/client/ClientPeerAddEvent.java
+++ b/api/src/main/java/com/craftmend/openaudiomc/api/events/client/ClientPeerAddEvent.java
@@ -8,7 +8,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class ClientPeerAddedEvent extends CancellableClientEvent {
+public class ClientPeerAddEvent extends CancellableClientEvent {
 
     private Client peer;
     private VoicePeerOptions options;
@@ -20,7 +20,7 @@ public class ClientPeerAddedEvent extends CancellableClientEvent {
      * @param peer    the peer that was added
      * @param options the options that were used to add the peer
      */
-    public ClientPeerAddedEvent(Client client, Client peer, VoicePeerOptions options) {
+    public ClientPeerAddEvent(Client client, Client peer, VoicePeerOptions options) {
         super(client);
         this.peer = peer;
         this.options = options;

--- a/api/src/main/java/com/craftmend/openaudiomc/api/events/client/ClientPeerAddedEvent.java
+++ b/api/src/main/java/com/craftmend/openaudiomc/api/events/client/ClientPeerAddedEvent.java
@@ -1,14 +1,14 @@
 package com.craftmend.openaudiomc.api.events.client;
 
 import com.craftmend.openaudiomc.api.clients.Client;
-import com.craftmend.openaudiomc.api.events.ClientEvent;
+import com.craftmend.openaudiomc.api.events.CancellableClientEvent;
 import com.craftmend.openaudiomc.api.voice.VoicePeerOptions;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
-public class ClientPeerAddedEvent extends ClientEvent {
+public class ClientPeerAddedEvent extends CancellableClientEvent {
 
     private Client peer;
     private VoicePeerOptions options;

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/client/objects/ClientConnection.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/client/objects/ClientConnection.java
@@ -320,6 +320,16 @@ public class ClientConnection implements Authenticatable, Client, Serializable,
     }
 
     @Override
+    public void kickProximityPeer(@NotNull Client otherClient) {
+        if (this.rtcSessionManager.isPeer(otherClient.getActor().getUniqueId())) {
+            // remove the peer
+            ClientConnection other = (ClientConnection) otherClient;
+            this.rtcSessionManager.getCurrentProximityPeers().remove(other.getActor().getUniqueId());
+            this.getPeerQueue().drop(other.getRtcSessionManager().getStreamKey());
+        }
+    }
+
+    @Override
     public void preloadMedia(String source) {
         ClientPreFetchPayload payload = new ClientPreFetchPayload(OpenAudioMc.getService(MediaService.class).process(source), "api", false);
         sendPacket(new PacketClientPreFetch(payload));

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/client/session/RtcSessionManager.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/client/session/RtcSessionManager.java
@@ -96,7 +96,7 @@ public class RtcSessionManager implements Serializable {
 
         // only force the other user to subscribe if they are not already listening to me and mutual is true
         if (mutual && !peer.getRtcSessionManager().currentProximityPeers.contains(clientConnection.getOwner().getUniqueId())) {
-            ClientPeerAddedEvent event = (ClientPeerAddedEvent) EventApi.getInstance().callEvent(new ClientPeerAddedEvent(
+            ClientPeerAddEvent event = (ClientPeerAddEvent) EventApi.getInstance().callEvent(new ClientPeerAddEvent(
                     clientConnection,
                     peer,
                     options
@@ -115,7 +115,7 @@ public class RtcSessionManager implements Serializable {
         if (currentProximityPeers.contains(peer.getOwner().getUniqueId()))
             return false;
 
-        ClientPeerAddedEvent event = (ClientPeerAddedEvent) EventApi.getInstance().callEvent(new ClientPeerAddedEvent(
+        ClientPeerAddEvent event = (ClientPeerAddEvent) EventApi.getInstance().callEvent(new ClientPeerAddEvent(
                 peer,
                 clientConnection,
                 options

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/client/session/RtcSessionManager.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/client/session/RtcSessionManager.java
@@ -96,16 +96,18 @@ public class RtcSessionManager implements Serializable {
 
         // only force the other user to subscribe if they are not already listening to me and mutual is true
         if (mutual && !peer.getRtcSessionManager().currentProximityPeers.contains(clientConnection.getOwner().getUniqueId())) {
-            peer.getRtcSessionManager().getCurrentProximityPeers().add(clientConnection.getOwner().getUniqueId());
-            peer.getPeerQueue().addSubscribe(clientConnection, peer, options);
-
-            EventApi.getInstance().callEvent(new ClientPeerAddedEvent(
+            ClientPeerAddedEvent event = (ClientPeerAddedEvent) EventApi.getInstance().callEvent(new ClientPeerAddedEvent(
                     clientConnection,
                     peer,
                     options
             ));
 
-            peer.getRtcSessionManager().updateLocationWatcher();
+            if (!event.isCancelled()) {
+                peer.getRtcSessionManager().getCurrentProximityPeers().add(clientConnection.getOwner().getUniqueId());
+                peer.getPeerQueue().addSubscribe(clientConnection, peer, options);
+
+                peer.getRtcSessionManager().updateLocationWatcher();
+            }
         }
 
         // in case that I'm already listening to the other user, don't do anything
@@ -113,16 +115,18 @@ public class RtcSessionManager implements Serializable {
         if (currentProximityPeers.contains(peer.getOwner().getUniqueId()))
             return false;
 
-        currentProximityPeers.add(peer.getOwner().getUniqueId());
-        clientConnection.getPeerQueue().addSubscribe(peer, clientConnection, options);
-
-        EventApi.getInstance().callEvent(new ClientPeerAddedEvent(
+        ClientPeerAddedEvent event = (ClientPeerAddedEvent) EventApi.getInstance().callEvent(new ClientPeerAddedEvent(
                 peer,
                 clientConnection,
                 options
         ));
 
-        updateLocationWatcher();
+        if (!event.isCancelled()) {
+            currentProximityPeers.add(peer.getOwner().getUniqueId());
+            clientConnection.getPeerQueue().addSubscribe(peer, clientConnection, options);
+            updateLocationWatcher();
+        }
+
         return true;
     }
 

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/events/adapter/LegacyEventAdapter.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/events/adapter/LegacyEventAdapter.java
@@ -69,7 +69,7 @@ public class LegacyEventAdapter {
     }
 
     @Handler
-    public void onPeerAdd(ClientPeerAddedEvent event) {
+    public void onPeerAdd(ClientPeerAddEvent event) {
         legacyEventDriver.fire(new com.craftmend.openaudiomc.api.impl.event.events.PlayerEnterVoiceProximityEvent(toClientConnection(event.getClient()), toClientConnection(event.getPeer())));
     }
 

--- a/plugin/src/main/java/com/craftmend/openaudiomc/spigot/modules/voicechat/SpigotVoiceChatService.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/spigot/modules/voicechat/SpigotVoiceChatService.java
@@ -4,8 +4,6 @@ import com.craftmend.openaudiomc.OpenAudioMc;
 import com.craftmend.openaudiomc.api.EventApi;
 import com.craftmend.openaudiomc.api.basic.Actor;
 import com.craftmend.openaudiomc.api.events.client.*;
-import com.craftmend.openaudiomc.api.impl.event.enums.TickEventType;
-import com.craftmend.openaudiomc.api.interfaces.AudioApi;
 import com.craftmend.openaudiomc.generic.client.objects.ClientConnection;
 import com.craftmend.openaudiomc.generic.client.session.RtcSessionManager;
 import com.craftmend.openaudiomc.generic.events.events.AccountAddTagEvent;
@@ -70,7 +68,7 @@ public class SpigotVoiceChatService extends Service {
             firstRun = false;
         });
 
-        eventApi.registerHandler(ClientPeerAddedEvent.class, event -> {
+        eventApi.registerHandler(ClientPeerAddEvent.class, event -> {
             // skip if this is disabled in the settings
             if (!event.getOptions().isSpatialAudio()) return; // exclude non-spatial audio clients
             if (!StorageKey.SETTINGS_VC_ANNOUNCEMENTS.getBoolean()) return;


### PR DESCRIPTION
Allow api consumers to cancel specific peer connections. An example implementation would be a case where spectators can hear everyone, but no one can hear spectators (unless the peer is also a spectator)

```java
EventApi.getInstance().registerHandler(ClientPeerAddedEvent.class, event -> {
    // First, convert both users to a Player
    Player client = Bukkit.getPlayer(event.getClient().getActor().getUniqueId()); // listener
    Player peer = Bukkit.getPlayer(event.getPeer().getActor().getUniqueId()); // speaker

    // safety check
    if (client == null || peer == null) return;

    // is the peer in spectator mode, and are we in something else
    if (peer.getGameMode() == GameMode.SPECTATOR && client.getGameMode() != GameMode.SPECTATOR) {
        // alright, we only want the spectator to hear the listener, and not the other way around
        event.setCancelled(true);
    }
});
```