### PR TITLE
Feature/auto reconnect

### DIFF
--- a/client/public/en.lang
+++ b/client/public/en.lang
@@ -143,4 +143,6 @@ settings.interpolation.title=Location smoothing
 settings.interpolation.body=Automatically smooth movements to minimize speaker/voicechat stuttering while walking. This adds extra movement delay, but sounds better.
 settings.interpolation.button=Enable smoothing
 
+network.serverUnhealthy={serverName}'s connection to OpenAudioMc is unhealthy, client functionality may be limited until the connection is restored.
+
 tooltip.close=Close

--- a/client/public/metadata.json
+++ b/client/public/metadata.json
@@ -1,1 +1,1 @@
-{"buildMajor":1,"buildMinor":125,"buildRevision":214,"buildTag":"dev","buildDate":"Mon Feb 19 2024","build":"1.125.214 dev"}
+{"buildMajor":1,"buildMinor":125,"buildRevision":218,"buildTag":"dev","buildDate":"Tue Feb 20 2024","build":"1.125.218 dev"}

--- a/client/src/client/services/socket/SocketModule.jsx
+++ b/client/src/client/services/socket/SocketModule.jsx
@@ -53,6 +53,14 @@ export const SocketManager = new class ISocketManager {
       TimeService.sync(timeStamp, hoursOffset);
     });
 
+    this.socket.on('server-reconnecting', () => {
+      setGlobalState({ isServerHealthy: false });
+    });
+
+    this.socket.on('server-reconnected', () => {
+      setGlobalState({ isServerHealthy: true });
+    });
+
     this.socket.on('disconnect', () => {
       MediaManager.destroySounds(null, true);
 

--- a/client/src/components/connectionwarning/ServerConnectionWarning.jsx
+++ b/client/src/components/connectionwarning/ServerConnectionWarning.jsx
@@ -1,0 +1,28 @@
+import { connect } from 'react-redux';
+import React from 'react';
+import { msg } from '../../client/OpenAudioAppContainer';
+
+function ServerConnectionWarning(props) {
+  if (props.isServerHealthy) {
+    return null;
+  }
+
+  const message = msg('network.serverUnhealthy').replace('{serverName}', props.settings.serverDisplayName || 'the server');
+
+  return (
+    <div className="pb-4">
+      <div className="bg-red-500 border border-red-400 text-white font-extrabold px-4 py-3 rounded relative flex justify-center" role="alert">
+        <span className="block">{message}</span>
+      </div>
+    </div>
+  );
+}
+
+export default connect(mapStateToProps)(ServerConnectionWarning);
+
+function mapStateToProps(state) {
+  return {
+    isServerHealthy: state.isServerHealthy,
+    settings: state.settings,
+  };
+}

--- a/client/src/components/tabwindow/TabWindow.jsx
+++ b/client/src/components/tabwindow/TabWindow.jsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { showTextModal } from '../modal/InputModal';
 import { setGlobalState } from '../../state/store';
 import { msg } from '../../client/OpenAudioAppContainer';
+import ServerConnectionWarning from '../connectionwarning/ServerConnectionWarning';
 
 export const setTab = (tab) => {
   setGlobalState({
@@ -57,6 +58,7 @@ class TabWindow extends Component {
       <div className="flex flex-col-reverse bg-gray-800 bg-opacity-25 text-white h-screen w-screen">
         <main className="flex justify-center overflow-x-hidden overflow-y-auto w-full h-full backdrop-blur">
           <div className="content-wrapper">
+            <ServerConnectionWarning />
             {pages[this.props.currentTab].content}
           </div>
         </main>

--- a/client/src/metadata.json
+++ b/client/src/metadata.json
@@ -1,1 +1,1 @@
-{"buildMajor":1,"buildMinor":125,"buildRevision":214,"buildTag":"dev","buildDate":"Mon Feb 19 2024","build":"1.125.214 dev"}
+{"buildMajor":1,"buildMinor":125,"buildRevision":218,"buildTag":"dev","buildDate":"Tue Feb 20 2024","build":"1.125.218 dev"}

--- a/client/src/state/store.jsx
+++ b/client/src/state/store.jsx
@@ -28,6 +28,7 @@ const initialState = {
 
   isPremium: false,
   isClaimed: false,
+  isServerHealthy: true,
   clientSupportsVoiceChat: false, // not valid https
   browserSupportsVoiceChat: false, // no webrtc at all
   browserSupportIsLimited: false, // operagx, broken settings?

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/abstracts/AbstractPacket.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/abstracts/AbstractPacket.java
@@ -1,6 +1,5 @@
 package com.craftmend.openaudiomc.generic.networking.abstracts;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -9,7 +8,6 @@ import java.util.UUID;
 
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
 public class AbstractPacket {
 
     /**
@@ -20,5 +18,13 @@ public class AbstractPacket {
     private AbstractPacketPayload data;
     private PacketChannel packetChannel;
     @Setter private UUID client;
+
+    public AbstractPacket(AbstractPacketPayload data, PacketChannel packetChannel, UUID client) {
+        this.data = data;
+        this.packetChannel = packetChannel;
+        this.client = client;
+    }
+
+    protected transient boolean queueableIfReconnecting = false;
 
 }

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/drivers/SystemDriver.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/drivers/SystemDriver.java
@@ -7,6 +7,7 @@ import com.craftmend.openaudiomc.generic.media.time.TimeService;
 import com.craftmend.openaudiomc.generic.networking.interfaces.NetworkingService;
 import com.craftmend.openaudiomc.generic.platform.interfaces.TaskService;
 import com.craftmend.openaudiomc.generic.state.StateService;
+import com.craftmend.openaudiomc.generic.state.states.ReconnectingState;
 import com.craftmend.openaudiomc.generic.storage.enums.StorageKey;
 import com.craftmend.openaudiomc.generic.client.objects.ClientConnection;
 import com.craftmend.openaudiomc.generic.networking.interfaces.SocketDriver;
@@ -18,17 +19,26 @@ import io.socket.client.Socket;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class SystemDriver implements SocketDriver {
 
-    private TaskService taskService = OpenAudioMc.resolveDependency(TaskService.class);
-    private StateService stateService = OpenAudioMc.getService(StateService.class);
+    private final TaskService taskService = OpenAudioMc.resolveDependency(TaskService.class);
+    private final StateService stateService = OpenAudioMc.getService(StateService.class);
+    private final SocketConnection parent;
+
     private Instant lastHeartbeat = Instant.now();
     private Socket lastSocket;
+    private boolean announcedShutdown = false;
+
+    public SystemDriver(SocketConnection socketConnection) {
+        this.parent = socketConnection;
+    }
 
     @Override
     public void boot(Socket socket, SocketConnection connector) {
         this.lastSocket = socket;
+        final AtomicBoolean died = new AtomicBoolean(false);
 
         taskService.scheduleAsyncRepeatingTask(() -> {
             if (stateService.getCurrentState().isConnected()) {
@@ -44,18 +54,40 @@ public class SystemDriver implements SocketDriver {
             OpenAudioMc.getService(TimeService.class).pushServerUpdate(timeStamp, offset);
         });
 
+        socket.on("announce-shutdown", args -> {
+            OpenAudioLogger.info("The server announced its intention to close our connection..");
+            announcedShutdown = true;
+        });
+
         socket.on(Socket.EVENT_CONNECT, args -> {
             // connected with success
-            OpenAudioMc.getService(StateService.class).setState(new ConnectedState(connector.getLastUsedRelay()));
+            announcedShutdown = false;
+            OpenAudioMc.getService(StateService.class).setState(new ConnectedState(connector.getPreviousLogin().getRelay()));
             pingHeartbeat();
             OpenAudioMc.getService(OpenaudioAccountService.class).startVoiceHandshake();
         });
 
-        socket.on(Socket.EVENT_DISCONNECT, args -> handleDisconnect());
+        socket.on(Socket.EVENT_DISCONNECT, args -> {
+            if (!died.get()) {
+                handleDisconnect();
+                died.set(true);
+            }
+        });
 
         socket.on(Socket.EVENT_CONNECT_TIMEOUT, args -> {
             // failed to connect
-            OpenAudioMc.getService(StateService.class).setState(new IdleState("Connecting timed out, something wrong with the api, network or token?"));
+            if (!died.get()) {
+                handleDisconnect();
+                died.set(true);
+            }
+        });
+
+        socket.on(Socket.EVENT_CONNECT_ERROR, args -> {
+            // failed to connect
+            if (!died.get()) {
+                handleDisconnect();
+                died.set(true);
+            }
         });
     }
 
@@ -87,8 +119,52 @@ public class SystemDriver implements SocketDriver {
     }
 
     private void handleDisconnect() {
+        boolean mayReconnect = true;
+        if (stateService.getCurrentState() instanceof ReconnectingState) {
+            ReconnectingState state = (ReconnectingState) stateService.getCurrentState();
+            if (state.getAttempts() >= ReconnectingState.MAX_ATTEMPTS) {
+                mayReconnect = false;
+            }
+        }
+
+        try {
+            lastSocket.disconnect();
+        } catch (Exception e) {
+            // ignored
+        }
+
+
+        if (announcedShutdown) {
+            OpenAudioLogger.info("The server closed the primary connection, but we were already aware of this. Ignoring.");
+            shutdown("Graceful.");
+        } else {
+            if (mayReconnect) {
+                // lets try again lol
+                // are we currently reconnecting?
+                if (stateService.getCurrentState() instanceof ReconnectingState) {
+                    ReconnectingState state = (ReconnectingState) stateService.getCurrentState();
+                    state.incrementAttempts();
+                } else {
+                    ReconnectingState reconnect = new ReconnectingState();
+                    reconnect.incrementAttempts();
+                    OpenAudioMc.getService(StateService.class).setState(reconnect);
+                }
+                OpenAudioLogger.warn("The server closed the primary connection unexpectedly, attempting reconnect in 2 seconds.");
+                OpenAudioMc.resolveDependency(TaskService.class).schduleSyncDelayedTask(() -> {
+                    parent.setupConnection();
+                }, 20 * 2);
+            } else {
+                OpenAudioLogger.warn("The server closed the primary connection unexpectedly, and the system has given up trying to reconnect.");
+                shutdown("Reached reconnect limit.");
+                // set to idle
+                OpenAudioMc.getService(StateService.class).setState(new IdleState("Disconnected from the socket. Reached reconnect limit."));
+            }
+        }
+    }
+
+    private void shutdown(String reason) {
         // disconnected, probably with a reason or something
-        OpenAudioMc.getService(StateService.class).setState(new IdleState("Disconnected from the socket"));
+        OpenAudioMc.getService(StateService.class).setState(new IdleState("Disconnected from the socket. " + reason));
 
         String message = Platform.translateColors(OpenAudioMc.getInstance().getConfiguration().getString(StorageKey.MESSAGE_LINK_EXPIRED));
         for (ClientConnection client : OpenAudioMc.getService(NetworkingService.class).getClients()) {
@@ -100,13 +176,9 @@ public class SystemDriver implements SocketDriver {
                 client.onDisconnect();
             }
         }
-
-        try {
-            lastSocket.disconnect();
-        } catch (Exception e) {
-            // ignored
-        }
-
         OpenAudioMc.getService(OpenaudioAccountService.class).getVoiceApiConnection().stop();
+
+        // reset
+        announcedShutdown = false;
     }
 }

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/drivers/SystemDriver.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/drivers/SystemDriver.java
@@ -150,9 +150,7 @@ public class SystemDriver implements SocketDriver {
                     OpenAudioMc.getService(StateService.class).setState(reconnect);
                 }
                 OpenAudioLogger.warn("The server closed the primary connection unexpectedly, attempting reconnect in 2 seconds.");
-                OpenAudioMc.resolveDependency(TaskService.class).schduleSyncDelayedTask(() -> {
-                    parent.setupConnection();
-                }, 20 * 2);
+                OpenAudioMc.resolveDependency(TaskService.class).schduleSyncDelayedTask(parent::setupConnection, 20 * 2);
             } else {
                 OpenAudioLogger.warn("The server closed the primary connection unexpectedly, and the system has given up trying to reconnect.");
                 shutdown("Reached reconnect limit.");

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/io/SocketConnection.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/io/SocketConnection.java
@@ -18,25 +18,32 @@ import com.craftmend.openaudiomc.generic.rest.response.NoResponse;
 import com.craftmend.openaudiomc.generic.rest.routes.Endpoint;
 import com.craftmend.openaudiomc.generic.rest.types.RelayLoginResponse;
 import com.craftmend.openaudiomc.generic.state.StateService;
+import com.craftmend.openaudiomc.generic.state.states.*;
 import com.craftmend.openaudiomc.generic.storage.enums.StorageKey;
 import com.craftmend.openaudiomc.generic.networking.interfaces.Authenticatable;
 import com.craftmend.openaudiomc.generic.networking.interfaces.SocketDriver;
-import com.craftmend.openaudiomc.generic.state.states.AssigningRelayState;
-import com.craftmend.openaudiomc.generic.state.states.ConnectedState;
-import com.craftmend.openaudiomc.generic.state.states.ConnectingState;
-import com.craftmend.openaudiomc.generic.state.states.IdleState;
 
 import com.craftmend.openaudiomc.generic.uploads.UploadIndexService;
 import io.socket.client.IO;
+import io.socket.client.Manager;
 import io.socket.client.Socket;
 
 import lombok.Getter;
 
+import okhttp3.Call;
 import okhttp3.OkHttpClient;
+import okhttp3.WebSocket;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.net.ProxySelector;
 import java.net.URISyntaxException;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 public class SocketConnection {
 
@@ -46,12 +53,12 @@ public class SocketConnection {
     private RestRequest<NoResponse> relayLogoutRequest;
     private boolean registeredLogout = false;
     @Getter
-    private String lastUsedRelay = "none";
+    private RelayLoginResponse previousLogin;
     private ServerKeySet keySet;
 
     private final SocketDriver[] drivers = new SocketDriver[]{
             new NotificationDriver(),
-            new SystemDriver(),
+            new SystemDriver(this),
             new ClientDriver(),
     };
 
@@ -60,10 +67,19 @@ public class SocketConnection {
     }
 
     public void setupConnection() {
-        if (!OpenAudioMc.getService(StateService.class).getCurrentState().canConnect()) return;
+        boolean isReconnect = OpenAudioMc.getService(StateService.class).getCurrentState() instanceof ReconnectingState;
+        int attempt = isReconnect ? ((ReconnectingState) OpenAudioMc.getService(StateService.class).getCurrentState()).getAttempts() : 0;
+        UUID stateId = isReconnect ? ((ReconnectingState) OpenAudioMc.getService(StateService.class).getCurrentState()).getStateId() : null;
+
+        if (!isReconnect && !OpenAudioMc.getService(StateService.class).getCurrentState().canConnect()) return;
 
         // update state
-        OpenAudioMc.getService(StateService.class).setState(new AssigningRelayState());
+        if (!isReconnect) {
+            // only override the state if we are not reconnecting
+            OpenAudioMc.getService(StateService.class).setState(new AssigningRelayState());
+        } else {
+            OpenAudioLogger.info("Attempting to restore connection to OpenAudioMc, attempt " + attempt);
+        }
 
         if (!registeredLogout) {
             relayLoginRequest = new RestRequest(RelayLoginResponse.class, Endpoint.RELAY_LOGIN);
@@ -83,68 +99,91 @@ public class SocketConnection {
         OkHttpClient okHttpClient = CertificateHelper.ignore(new OkHttpClient.Builder().proxySelector(new NullProxySelector())).build();
 
         IO.Options opts = new IO.Options();
-        opts.callFactory = okHttpClient;
+        opts.callFactory = (Call.Factory) okHttpClient;
         opts.reconnection = false;
-        opts.webSocketFactory = okHttpClient;
+        opts.webSocketFactory = (WebSocket.Factory) okHttpClient;
+        opts.forceNew = true;
+        opts.rememberUpgrade = false;
 
         // authentication headers
         opts.query = String.format(
-                "type=server&private=%s&public=%s",
+                "type=server&private=%s&public=%s&reconnect=%s",
                 keySet.getPrivateKey().getValue(),
-                keySet.getPublicKey().getValue()
+                keySet.getPublicKey().getValue(),
+                isReconnect ? "true" : "false"
         );
 
-        // schedule timeout check
-        OpenAudioMc.resolveDependency(TaskService.class).schduleSyncDelayedTask(() -> {
-            if (OpenAudioMc.getService(StateService.class).getCurrentState() instanceof AssigningRelayState) {
-                OpenAudioLogger.info("Connecting timed out.");
-                OpenAudioMc.getService(StateService.class).setState(new IdleState("Connecting to OpenAudioMc timed out"));
-            }
-        }, 20 * 35);
+        // only do login handling if we're not reconnecting, because then we'd be re-using the same config
+        if (!isReconnect) {
+            OpenAudioMc.resolveDependency(TaskService.class).schduleSyncDelayedTask(() -> {
+                if (OpenAudioMc.getService(StateService.class).getCurrentState() instanceof AssigningRelayState) {
+                    OpenAudioLogger.info("Connecting timed out.");
+                    OpenAudioMc.getService(StateService.class).setState(new IdleState("Connecting to OpenAudioMc timed out"));
+                }
+            }, 20 * 35);
 
-        relayLoginRequest.run();
+            relayLoginRequest.run();
 
-        if (relayLoginRequest.hasError()) {
-            OpenAudioMc.getService(StateService.class).setState(new IdleState("Failed to do the initial handshake. Error: " + relayLoginRequest.getError()));
-            OpenAudioLogger.info("Failed to get instance: " + relayLoginRequest.getError().getMessage());
-            try {
-                throw new IOException("Failed to get instance! see console for error information");
-            } catch (IOException e) {
-                e.printStackTrace();
+            if (relayLoginRequest.hasError()) {
+                OpenAudioMc.getService(StateService.class).setState(new IdleState("Failed to do the initial handshake. Error: " + relayLoginRequest.getError()));
+                OpenAudioLogger.info("Failed to get instance: " + relayLoginRequest.getError().getMessage());
+                try {
+                    throw new IOException("Failed to get instance! see console for error information");
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+                return;
             }
+
+            RelayLoginResponse loginResponse = relayLoginRequest.getResponse();
+            previousLogin = loginResponse;
+            OpenAudioMc.getService(UploadIndexService.class).setContent(loginResponse.getFiles());
+        }
+
+        if (previousLogin == null) {
+            OpenAudioMc.getService(StateService.class).setState(new IdleState("Failed to get a relay instance"));
+            OpenAudioLogger.warn("Entered a track which should only be entered during recovery, but there was no previous login. reconnect: " + isReconnect + " attempt: " + attempt);
             return;
         }
 
-        RelayLoginResponse loginResponse = relayLoginRequest.getResponse();
-
-        lastUsedRelay = loginResponse.getRelay();
-        OpenAudioMc.getService(UploadIndexService.class).setContent(loginResponse.getFiles());
-
         try {
-            String endpoint = loginResponse.getRelayEndpoint();
+            String endpoint = previousLogin.getRelayEndpoint();
             endpoint = endpoint.replace("https", "http");
             socket = IO.socket(endpoint, opts);
         } catch (URISyntaxException e) {
             OpenAudioLogger.error(e, "Received an invalid endpoint");
         }
 
-        // register state to be connecting
-        OpenAudioMc.getService(StateService.class).setState(new ConnectingState());
+        // this should again, only be done if we're not reconnecting
+        if (!isReconnect) {
+            // register state to be connecting
+            OpenAudioMc.getService(StateService.class).setState(new ConnectingState());
 
-        // clear session cache
-        OpenAudioMc.getService(AuthenticationService.class).getDriver().initCache();
+            // clear session cache
+            OpenAudioMc.getService(AuthenticationService.class).getDriver().initCache();
+        }
 
         // schedule timeout check
         OpenAudioMc.resolveDependency(TaskService.class).schduleSyncDelayedTask(() -> {
+            // was it a normal connection?
             if (OpenAudioMc.getService(StateService.class).getCurrentState() instanceof ConnectingState) {
                 OpenAudioLogger.warn("Connect timed out.");
                 OpenAudioMc.getService(StateService.class).setState(new IdleState("Connecting to the assigned instance timed out (socket)"));
+            }
+
+            // alternatively, check if we're still in the same reconnect cycle
+            if (OpenAudioMc.getService(StateService.class).getCurrentState() instanceof ReconnectingState) {
+                ReconnectingState state = (ReconnectingState) OpenAudioMc.getService(StateService.class).getCurrentState();
+                if (state.getStateId().equals(stateId) && state.getAttempts() == attempt) {
+                    socket.emit(Socket.EVENT_CONNECT_TIMEOUT);
+                }
             }
         }, 20 * 35);
 
 
         // register drivers
         for (SocketDriver driver : drivers) driver.boot(socket, this);
+
         socket.connect();
     }
 
@@ -153,6 +192,8 @@ public class SocketConnection {
             relayLogoutRequest.run();
         }
         if (this.socket != null) {
+            // let them know that we intend to shut down
+            this.socket.emit("announce-shutdown", "goodbye");
             this.socket.disconnect();
         }
         OpenAudioMc.getService(StateService.class).setState(new IdleState());
@@ -166,4 +207,5 @@ public class SocketConnection {
             socket.emit("data", OpenAudioMc.getGson().toJson(packet));
         }
     }
+
 }

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/io/SocketConnection.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/io/SocketConnection.java
@@ -5,6 +5,7 @@ import com.craftmend.openaudiomc.api.EventApi;
 import com.craftmend.openaudiomc.generic.authentication.AuthenticationService;
 import com.craftmend.openaudiomc.generic.authentication.objects.ServerKeySet;
 import com.craftmend.openaudiomc.generic.events.events.StateChangeEvent;
+import com.craftmend.openaudiomc.generic.networking.DefaultNetworkingService;
 import com.craftmend.openaudiomc.generic.oac.OpenaudioAccountService;
 import com.craftmend.openaudiomc.generic.logging.OpenAudioLogger;
 import com.craftmend.openaudiomc.generic.networking.certificate.CertificateHelper;
@@ -19,13 +20,11 @@ import com.craftmend.openaudiomc.generic.rest.routes.Endpoint;
 import com.craftmend.openaudiomc.generic.rest.types.RelayLoginResponse;
 import com.craftmend.openaudiomc.generic.state.StateService;
 import com.craftmend.openaudiomc.generic.state.states.*;
-import com.craftmend.openaudiomc.generic.storage.enums.StorageKey;
 import com.craftmend.openaudiomc.generic.networking.interfaces.Authenticatable;
 import com.craftmend.openaudiomc.generic.networking.interfaces.SocketDriver;
 
 import com.craftmend.openaudiomc.generic.uploads.UploadIndexService;
 import io.socket.client.IO;
-import io.socket.client.Manager;
 import io.socket.client.Socket;
 
 import lombok.Getter;
@@ -35,17 +34,13 @@ import okhttp3.OkHttpClient;
 import okhttp3.WebSocket;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.net.ProxySelector;
 import java.net.URISyntaxException;
 import java.util.UUID;
-import java.util.function.Consumer;
-import java.util.logging.Handler;
-import java.util.logging.Level;
-import java.util.logging.LogRecord;
-import java.util.logging.Logger;
 
 public class SocketConnection {
+
+    @Getter private final DefaultNetworkingService parent;
 
     private Socket socket;
     @Getter
@@ -62,8 +57,9 @@ public class SocketConnection {
             new ClientDriver(),
     };
 
-    public SocketConnection(ServerKeySet keySet) {
+    public SocketConnection(ServerKeySet keySet, DefaultNetworkingService defaultNetworkingService) {
         this.keySet = keySet;
+        this.parent = defaultNetworkingService;
     }
 
     public void setupConnection() {

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/packets/PacketAcknowledgeClientRequest.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/packets/PacketAcknowledgeClientRequest.java
@@ -8,6 +8,7 @@ public class PacketAcknowledgeClientRequest extends AbstractPacket {
 
     public PacketAcknowledgeClientRequest(AcknowledgeClientPayload data) {
         super(data, PacketChannel.SOCKET_OUT_ACKNOWLEDGEMENT, null);
+        this.queueableIfReconnecting = true;
     }
 
 }

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/packets/PacketSocketKickClient.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/packets/PacketSocketKickClient.java
@@ -7,6 +7,7 @@ public class PacketSocketKickClient extends AbstractPacket {
 
     public PacketSocketKickClient() {
         super(null, PacketChannel.SOCKET_OUT_KICK_CLIENT, null);
+        this.queueableIfReconnecting = true;
     }
 
 }

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/packets/client/media/PacketClientCreateMedia.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/packets/client/media/PacketClientCreateMedia.java
@@ -9,10 +9,12 @@ public class PacketClientCreateMedia extends AbstractPacket {
 
     public PacketClientCreateMedia(Media media) {
         super(new ClientCreateMediaPayload(media), PacketChannel.CLIENT_OUT_CREATE_MEDIA, null);
+        this.queueableIfReconnecting = true;
     }
 
     public PacketClientCreateMedia(Media media, int distance, int maxDistance) {
         super(new ClientCreateMediaPayload(media, distance, maxDistance), PacketChannel.CLIENT_OUT_CREATE_MEDIA, null);
+        this.queueableIfReconnecting = true;
     }
 
 }

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/packets/client/media/PacketClientDestroyMedia.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/packets/client/media/PacketClientDestroyMedia.java
@@ -10,18 +10,22 @@ public class PacketClientDestroyMedia extends AbstractPacket {
 
     public PacketClientDestroyMedia(String soundId, boolean deleteSpecial, int fadeTime) {
         super(new ClientDestroyMediaPayload(soundId, deleteSpecial, fadeTime), PacketChannel.CLIENT_OUT_DESTROY_MEDIA, null);
+        this.queueableIfReconnecting = true;
     }
 
     public PacketClientDestroyMedia(String soundId, boolean deleteSpecial) {
         super(new ClientDestroyMediaPayload(soundId, deleteSpecial, DEFAULT_FADE_TIME), PacketChannel.CLIENT_OUT_DESTROY_MEDIA, null);
+        this.queueableIfReconnecting = true;
     }
 
     public PacketClientDestroyMedia(String soundId, int fadeTime) {
         super(new ClientDestroyMediaPayload(soundId, false, fadeTime), PacketChannel.CLIENT_OUT_DESTROY_MEDIA, null);
+        this.queueableIfReconnecting = true;
     }
 
     public PacketClientDestroyMedia(String soundId) {
         super(new ClientDestroyMediaPayload(soundId, false, DEFAULT_FADE_TIME), PacketChannel.CLIENT_OUT_DESTROY_MEDIA, null);
+        this.queueableIfReconnecting = true;
     }
 
 }

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/packets/client/media/PacketClientUpdateMedia.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/packets/client/media/PacketClientUpdateMedia.java
@@ -9,6 +9,7 @@ public class PacketClientUpdateMedia extends AbstractPacket {
 
     public PacketClientUpdateMedia(MediaUpdate update) {
         super(new ClientUpdateMediaPayload(update), PacketChannel.CLIENT_OUT_UPDATE_MEDIA, null);
+        this.queueableIfReconnecting = true;
     }
 
 }

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/packets/client/speakers/PacketClientCreateSpeaker.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/packets/client/speakers/PacketClientCreateSpeaker.java
@@ -12,6 +12,7 @@ public class PacketClientCreateSpeaker extends AbstractPacket {
                 PacketChannel.CLIENT_OUT_SPEAKER_CREATE,
                 null
         );
+        this.queueableIfReconnecting = true;
     }
 
 }

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/packets/client/speakers/PacketClientRemoveSpeaker.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/packets/client/speakers/PacketClientRemoveSpeaker.java
@@ -12,6 +12,7 @@ public class PacketClientRemoveSpeaker extends AbstractPacket {
                 PacketChannel.CLIENT_OUT_SPEAKER_DESTROY,
                 null
         );
+        this.queueableIfReconnecting = true;
     }
 
 }

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/packets/client/ui/PacketClientModerationStatus.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/packets/client/ui/PacketClientModerationStatus.java
@@ -12,6 +12,7 @@ public class PacketClientModerationStatus extends AbstractPacket {
                 PacketChannel.CLIENT_OUT_MODERATION_STATUS,
                 null
         );
+        this.queueableIfReconnecting = true;
     }
 
 }

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/packets/client/voice/PacketClientBlurVoiceUi.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/packets/client/voice/PacketClientBlurVoiceUi.java
@@ -12,6 +12,7 @@ public class PacketClientBlurVoiceUi extends AbstractPacket {
                 PacketChannel.CLIENT_OUT_VOICE_BLUR,
                 null
         );
+        this.queueableIfReconnecting = true;
     }
 
 }

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/packets/client/voice/PacketClientDropVoiceStream.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/packets/client/voice/PacketClientDropVoiceStream.java
@@ -12,6 +12,7 @@ public class PacketClientDropVoiceStream extends AbstractPacket {
                 PacketChannel.CLIENT_OUT_VOICE_DROP_STREAM,
                 null
         );
+        this.queueableIfReconnecting = true;
     }
 
 }

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/packets/client/voice/PacketClientSubscribeToVoice.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/packets/client/voice/PacketClientSubscribeToVoice.java
@@ -12,6 +12,7 @@ public class PacketClientSubscribeToVoice extends AbstractPacket {
                 PacketChannel.CLIENT_OUT_VOICE_SUBSCRIBE,
                 null
         );
+        this.queueableIfReconnecting = true;
     }
 
 }

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/packets/client/voice/PacketClientUnlockVoiceChat.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/packets/client/voice/PacketClientUnlockVoiceChat.java
@@ -12,6 +12,7 @@ public class PacketClientUnlockVoiceChat extends AbstractPacket {
                 PacketChannel.CLIENT_OUT_VOICE_UNLOCK,
                 null
         );
+        this.queueableIfReconnecting = true;
     }
 
 }

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/packets/client/voice/PacketClientVoiceOptionsUpdate.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/packets/client/voice/PacketClientVoiceOptionsUpdate.java
@@ -12,6 +12,7 @@ public class PacketClientVoiceOptionsUpdate extends AbstractPacket {
                 PacketChannel.CLIENT_OUT_PEER_OPTIONS,
                 null
         );
+        this.queueableIfReconnecting = true;
     }
 
 }

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/queue/PacketQueue.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/networking/queue/PacketQueue.java
@@ -1,0 +1,79 @@
+package com.craftmend.openaudiomc.generic.networking.queue;
+
+import com.craftmend.openaudiomc.OpenAudioMc;
+import com.craftmend.openaudiomc.generic.client.objects.ClientConnection;
+import com.craftmend.openaudiomc.generic.logging.OpenAudioLogger;
+import com.craftmend.openaudiomc.generic.networking.DefaultNetworkingService;
+import com.craftmend.openaudiomc.generic.networking.abstracts.AbstractPacket;
+import com.craftmend.openaudiomc.generic.state.StateService;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class PacketQueue {
+
+    private Map<UUID, List<AbstractPacket>> packetQueue = new ConcurrentHashMap<>();
+
+    public void addPacket(UUID uuid, AbstractPacket packet) {
+        if (!packetQueue.containsKey(uuid)) {
+            packetQueue.put(uuid, new LinkedList<>());
+        }
+        packetQueue.get(uuid).add(packet);
+    }
+
+    public void clearAll() {
+        packetQueue.clear();
+    }
+
+    public void flush(DefaultNetworkingService networkingService) {
+        if (packetQueue.isEmpty()) return;
+
+        // gradually flush
+        new Thread(() -> {
+            boolean cancelled = false;
+            List<UUID> toRemove = new LinkedList<>();
+            for (Map.Entry<UUID, List<AbstractPacket>> entry : packetQueue.entrySet()) {
+                // is this user still connected?
+                ClientConnection clientConnection = networkingService.getClient(entry.getKey());
+                if (clientConnection != null && clientConnection.isConnected()) {
+                    // send all packets
+                    int flushed = 0;
+                    for (AbstractPacket packet : entry.getValue()) {
+                        networkingService.send(clientConnection, packet);
+                        flushed++;
+                    }
+
+                    if (flushed > 0) {
+                        OpenAudioLogger.info("Flushed " + flushed + " packets for " + entry.getKey());
+                        // wait 15 MS before flushing the next user
+                        try {
+                            Thread.sleep(15);
+                        } catch (InterruptedException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                    toRemove.add(entry.getKey());
+                }
+
+                // check if the connection is still OK before we continue
+                if (!OpenAudioMc.getService(StateService.class).getCurrentState().isConnected()) {
+                    OpenAudioLogger.warn("Connection was lost, stopping packet flush");
+                    cancelled = true;
+                    break;
+                }
+            }
+
+            if (cancelled) {
+                // only remove the ones we already flushed
+                for (UUID uuid : toRemove) {
+                    packetQueue.remove(uuid);
+                }
+            } else {
+                clearAll();
+            }
+        }).start();
+    }
+}

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/state/states/ReconnectingState.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/state/states/ReconnectingState.java
@@ -1,0 +1,33 @@
+package com.craftmend.openaudiomc.generic.state.states;
+
+import com.craftmend.openaudiomc.generic.state.interfaces.State;
+import lombok.Getter;
+
+import java.util.UUID;
+
+public class ReconnectingState implements State {
+
+    public static final int MAX_ATTEMPTS = 7;
+    @Getter private int attempts = 0;
+
+    @Getter private UUID stateId = UUID.randomUUID();
+
+    @Override
+    public String getDescription() {
+        return "Attempting to reconnect.. Attempt " + attempts + " of " + MAX_ATTEMPTS;
+    }
+
+    @Override
+    public boolean isConnected() {
+        return false;
+    }
+
+    @Override
+    public boolean canConnect() {
+        return false;
+    }
+
+    public void incrementAttempts() {
+        attempts++;
+    }
+}

--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/voicechat/enums/VoiceApiStatus.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/voicechat/enums/VoiceApiStatus.java
@@ -4,6 +4,7 @@ public enum VoiceApiStatus {
 
     IDLE,
     CONNECTING,
+    RECONNECTING,
     CONNECTED
 
 }

--- a/plugin/src/main/java/com/craftmend/openaudiomc/spigot/modules/commands/subcommands/SpamTestSubCommand.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/spigot/modules/commands/subcommands/SpamTestSubCommand.java
@@ -1,0 +1,41 @@
+package com.craftmend.openaudiomc.spigot.modules.commands.subcommands;
+
+import com.craftmend.openaudiomc.OpenAudioMc;
+import com.craftmend.openaudiomc.generic.commands.interfaces.SubCommand;
+import com.craftmend.openaudiomc.generic.commands.objects.Argument;
+import com.craftmend.openaudiomc.generic.database.DatabaseService;
+import com.craftmend.openaudiomc.generic.user.User;
+import com.craftmend.openaudiomc.spigot.modules.shortner.AliasService;
+import com.craftmend.openaudiomc.spigot.modules.shortner.data.Alias;
+import org.bukkit.ChatColor;
+
+public class SpamTestSubCommand extends SubCommand {
+
+    public SpamTestSubCommand() {
+        super("alias");
+        registerArguments(
+                new Argument("<alias name> <source>",
+                        "Register a Alias for a source URL so you can easaly memorize them and can paste them onto signs without having to type a complete dictionary." +
+                                " When an alias like onride_music is set, you can trigger it by using a:onride_music as your source.")
+        );
+    }
+
+    @Override
+    public void onExecute(User sender, String[] args) {
+        if (args.length == 2) {
+            String aliasName = args[0].toLowerCase();
+            String aliasSource = args[1];
+            Alias alias = new Alias(aliasName, aliasSource);
+            OpenAudioMc.getService(AliasService.class).getAliasMap().put(aliasName, alias);
+
+            OpenAudioMc.getService(DatabaseService.class).getRepository(Alias.class)
+                    .save(alias);
+
+            message(sender, ChatColor.GREEN + "Success! the alias " + ChatColor.YELLOW + "a:" + aliasName.toLowerCase() + ChatColor.GRAY + " will be read as " + ChatColor.YELLOW + aliasSource);
+            return;
+        }
+
+        sender.makeExecuteCommand("oa help " + getCommand());
+    }
+
+}


### PR DESCRIPTION
Implement connection recovery between the plugin and our infrastructure, for client events and the voicechat bus.

Before this PR, all clients would be forcefully kicked if either of those two connections were lost, which could happen for several reasons. However, with this new feature, the plugin will queue important packets to sync back up when the connection is re-established.

This also goes hand-in-hand with some major backend changes, to allow for the new connection type and to "freeze" clients that are waiting for the server to reconnect. (this is a grace period, clients will still be closed if the server does not reappear within a reasonable amount of time.)

![image](https://github.com/Mindgamesnl/OpenAudioMc/assets/10709682/32cc77d9-8004-427d-a5c4-281f47a99ff4)
