### PR TITLE
Drop legacy module

### DIFF
--- a/plugin/src/main/java/com/craftmend/openaudiomc/generic/modules/ModuleLoaderService.java
+++ b/plugin/src/main/java/com/craftmend/openaudiomc/generic/modules/ModuleLoaderService.java
@@ -10,13 +10,9 @@ import lombok.SneakyThrows;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -32,13 +28,6 @@ public class ModuleLoaderService extends Service {
     public ModuleLoaderService() {
         File modulesDir = new File(MagicValue.STORAGE_DIRECTORY.get(File.class), "/modules");
         modulesDir.mkdirs();
-
-        // download default modules
-        if (!new File(modulesDir, "migrate.map-to-storm.jar").exists()) {
-            log("Downloading default migration module");
-            InputStream in = new URL("https://github.com/Mindgamesnl/OpenAudioMc/raw/master/modules/migrate.map-to-storm.jar").openStream();
-            Files.copy(in, Paths.get(new File(modulesDir, "migrate.map-to-storm.jar").getPath()), StandardCopyOption.REPLACE_EXISTING);
-        }
 
         if (modulesDir.isDirectory()) {
             log("Loading modules from " + modulesDir.getAbsolutePath());


### PR DESCRIPTION
This prevents the old legacy migration module from loading by default.
Its original purpose was to migrate from a proprietary flat file to the sqlite which we use now, but support for this has been dropped a few years ago now and there's no reason to believe that any servers would still need to make this migration.

**if**, for some reason, a server pops up in support that still needs to migrate after all these years, then it's still possible to do so by manually using the module jar.